### PR TITLE
relax pytorch-ie version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 REQUIRED_PKGS = [
-    "pytorch-ie>=0.8.0,<0.9.0",
+    "pytorch-ie>=0.8.0,<1.0.0",
 ]
 
 TESTS_REQUIRE = [


### PR DESCRIPTION
set upper bound for pytorch-ie to 1.0.0 to mitigate the need for a new release each time a new _minor_ pytorch-ie release comes out