### PR TITLE
add show text lengths processor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -80,7 +80,8 @@ repos:
       - id: codespell
         args:
           - --skip=logs/**,data/**
-          # - --ignore-words-list=abc,def
+          # required for plotext.hist()
+          - --ignore-words-list=hist
 
   # python static type checking
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ REQUIRED_PKGS = [
 TESTS_REQUIRE = [
     "pytest",
     "pytest-cov",
+    "plotext",
 ]
 
 QUALITY_REQUIRE = [

--- a/src/pie_utils/processor/document/__init__.py
+++ b/src/pie_utils/processor/document/__init__.py
@@ -6,6 +6,11 @@ from pytorch_ie.documents import TextDocument
 
 
 @dataclass
+class DocumentWithPartition(TextDocument):
+    partition: AnnotationList[Span] = annotation_field(target="text")
+
+
+@dataclass
 class DocumentWithEntitiesRelationsAndPartition(TextDocument):
     entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
     relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")

--- a/src/pie_utils/processor/document/text_lengths_collector.py
+++ b/src/pie_utils/processor/document/text_lengths_collector.py
@@ -29,6 +29,8 @@ class TextLengthsCollector(WithStatistics):
         collect the lengths for the partition entries (e.g. sentences or sections) individually.
     :param tokenizer_kwargs a dictionary containing further keyword arguments passed when calling
         the tokenizer
+    :param plotext_kwargs a dictionary containing further keyword arguments passed when calling
+        plotext.hist().
     """
 
     def __init__(
@@ -36,11 +38,13 @@ class TextLengthsCollector(WithStatistics):
         tokenizer_name_or_path: str,
         use_partition: bool | None = False,
         tokenizer_kwargs: dict | None = None,
+        plotext_kwargs: dict | None = None,
     ):
         self.use_partition = use_partition
         self.tokenizer_name_or_path = tokenizer_name_or_path
         self.tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name_or_path)
         self.tokenizer_kwargs = tokenizer_kwargs or {}
+        self.plotext_kwargs = plotext_kwargs or {}
         self.reset_statistics()
 
     def reset_statistics(self):
@@ -55,7 +59,7 @@ class TextLengthsCollector(WithStatistics):
             import plotext as plt
 
             plt.clf()
-            plt.hist(data=self.text_lengths)
+            plt.hist(data=self.text_lengths, **self.plotext_kwargs)
             plt.title(caption)
             plt.show()
 

--- a/src/pie_utils/processor/document/text_lengths_collector.py
+++ b/src/pie_utils/processor/document/text_lengths_collector.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+
+from pytorch_ie.annotations import Span
+from transformers import AutoTokenizer
+
+from pie_utils.statistics import WithStatistics
+
+from ..document import DocumentWithPartition
+
+logger = logging.getLogger(__name__)
+
+
+class TextLengthsCollector(WithStatistics):
+    def __init__(
+        self,
+        tokenizer_name_or_path: str,
+        use_partition: bool | None = False,
+        tokenizer_kwargs: dict | None = None,
+    ):
+        self.use_partition = use_partition
+        self.tokenizer_name_or_path = tokenizer_name_or_path
+        self.tokenizer = AutoTokenizer.from_pretrained(self.tokenizer_name_or_path)
+        self.tokenizer_kwargs = tokenizer_kwargs or {}
+        self.reset_statistics()
+
+    def reset_statistics(self):
+        self.text_lengths = []
+
+    def show_statistics(self, description: str | None = None):
+        description = description or "Statistics for text lengths"
+        caption = f"{description} (tokenizer_name_or_path={self.tokenizer_name_or_path})"
+        try:
+            import plotext as plt
+
+            plt.clf()
+            plt.hist(data=self.text_lengths)
+            plt.title(caption)
+            plt.show()
+
+        # exclude from test coverage since this would require to uninstall plotext and
+        # just a simple logging is performed
+        except ModuleNotFoundError:  # pragma: no cover
+            logger.info("install plotext to display the data as histogram at the console")
+
+        stats = {
+            "min": min(self.text_lengths),
+            "max": max(self.text_lengths),
+            "mean": statistics.mean(self.text_lengths),
+            "stddev": statistics.pstdev(self.text_lengths),
+        }
+
+        logger.info(f"{caption}):\n{json.dumps(stats, indent=2)}")
+
+    def __call__(self, document: DocumentWithPartition) -> DocumentWithPartition:
+        partition = (
+            document.partition if self.use_partition else [Span(start=0, end=len(document.text))]
+        )
+        tokenized = self.tokenizer(
+            [document.text[part.start : part.end] for part in partition], **self.tokenizer_kwargs
+        )
+        new_lengths = [len(encoding) for encoding in tokenized.encodings]
+        self.text_lengths.extend(new_lengths)
+        return document

--- a/src/pie_utils/processor/document/text_lengths_collector.py
+++ b/src/pie_utils/processor/document/text_lengths_collector.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class TextLengthsCollector(WithStatistics):
-    """This document processors collects the text lengths in means of token numbers and allows to
+    """This document processor collects the text lengths in means of token numbers and allows to
     show them as json dict and, if plotext is installed, as histogram. Its nature is purely
     statistical, it does not modify the documents.
 

--- a/src/pie_utils/processor/document/text_lengths_collector.py
+++ b/src/pie_utils/processor/document/text_lengths_collector.py
@@ -29,6 +29,8 @@ class TextLengthsCollector(WithStatistics):
 
     def reset_statistics(self):
         self.text_lengths = []
+        self.num_docs = 0
+        self.num_parts = 0
 
     def show_statistics(self, description: str | None = None):
         description = description or "Statistics for text lengths"
@@ -51,7 +53,10 @@ class TextLengthsCollector(WithStatistics):
             "max": max(self.text_lengths),
             "mean": statistics.mean(self.text_lengths),
             "stddev": statistics.pstdev(self.text_lengths),
+            "num_docs": self.num_docs,
         }
+        if self.use_partition:
+            stats["num_parts"] = self.num_parts
 
         logger.info(f"{caption}):\n{json.dumps(stats, indent=2)}")
 
@@ -64,4 +69,6 @@ class TextLengthsCollector(WithStatistics):
         )
         new_lengths = [len(encoding) for encoding in tokenized.encodings]
         self.text_lengths.extend(new_lengths)
+        self.num_parts += len(partition)
+        self.num_docs += 1
         return document

--- a/src/pie_utils/processor/document/text_lengths_collector.py
+++ b/src/pie_utils/processor/document/text_lengths_collector.py
@@ -15,6 +15,22 @@ logger = logging.getLogger(__name__)
 
 
 class TextLengthsCollector(WithStatistics):
+    """This document processors collects the text lengths in means of token numbers and allows to
+    show them as json dict and, if plotext is installed, as histogram. Its nature is purely
+    statistical, it does not modify the documents.
+
+    Presented values:
+     * min, max, mean, and stddev of the collected text lengths,
+     * num_docs (number of processed documents), and
+     * if use_partition is enabled, num_parts (number of precessed parts)
+
+    :param tokenizer_name_or_path the identifier of the Huggingface tokenizer that will be used
+    :param use_partition a boolean flag to enable considering a partition, i.e. tokenize and
+        collect the lengths for the partition entries (e.g. sentences or sections) individually.
+    :param tokenizer_kwargs a dictionary containing further keyword arguments passed when calling
+        the tokenizer
+    """
+
     def __init__(
         self,
         tokenizer_name_or_path: str,
@@ -44,7 +60,7 @@ class TextLengthsCollector(WithStatistics):
             plt.show()
 
         # exclude from test coverage since this would require to uninstall plotext and
-        # just a simple logging is performed
+        # just a simple logging is performed here
         except ModuleNotFoundError:  # pragma: no cover
             logger.info("install plotext to display the data as histogram at the console")
 

--- a/tests/processor/document/test_text_lengths_collector.py
+++ b/tests/processor/document/test_text_lengths_collector.py
@@ -12,6 +12,7 @@ def test_text_lengths_collector():
     processed_document = text_lengths_collector(document)
     assert document == processed_document
     assert text_lengths_collector.text_lengths == [14]
+    assert text_lengths_collector.num_docs == 1
 
 
 def test_text_lengths_collector_with_partition():
@@ -32,5 +33,7 @@ def test_text_lengths_collector_with_partition():
     processed_document = text_lengths_collector(document)
     assert document == processed_document
     assert text_lengths_collector.text_lengths == [7, 9]
+    assert text_lengths_collector.num_docs == 1
+    assert text_lengths_collector.num_parts == 2
 
     text_lengths_collector.show_statistics()

--- a/tests/processor/document/test_text_lengths_collector.py
+++ b/tests/processor/document/test_text_lengths_collector.py
@@ -1,0 +1,36 @@
+from pytorch_ie.annotations import Span
+
+from pie_utils.processor.document import DocumentWithPartition
+from pie_utils.processor.document.text_lengths_collector import TextLengthsCollector
+
+
+def test_text_lengths_collector():
+    text_lengths_collector = TextLengthsCollector(
+        tokenizer_name_or_path="bert-base-uncased",
+    )
+    document = DocumentWithPartition(text="Jane lives in Berlin. This is a sentence about Karl.\n")
+    processed_document = text_lengths_collector(document)
+    assert document == processed_document
+    assert text_lengths_collector.text_lengths == [14]
+
+
+def test_text_lengths_collector_with_partition():
+    text_lengths_collector = TextLengthsCollector(
+        tokenizer_name_or_path="bert-base-uncased",
+        use_partition=True,
+    )
+    document = DocumentWithPartition(text="Jane lives in Berlin. This is a sentence about Karl.\n")
+    sentence1_text = "Jane lives in Berlin."
+    sentence1 = Span(start=0, end=len(sentence1_text))
+    document.partition.append(sentence1)
+    assert str(sentence1) == sentence1_text
+    sentence2_text = "This is a sentence about Karl."
+    sentence2 = Span(start=sentence1.end + 1, end=sentence1.end + 1 + len(sentence2_text))
+    document.partition.append(sentence2)
+    assert str(sentence2) == sentence2_text
+
+    processed_document = text_lengths_collector(document)
+    assert document == processed_document
+    assert text_lengths_collector.text_lengths == [7, 9]
+
+    text_lengths_collector.show_statistics()


### PR DESCRIPTION
This PR adds the `TextLengthsCollector` document processor. It collects the text lengths in means of token numbers and allows to show some statistics as json dict and, if plotext is installed, its histogram. Its nature is purely statistical, it does not modify the documents. Optionally, it can work partition wise, i.e. per sentence or section, if a partition is provided.

Presented values:
 * `min`, `max`, `mean`, and `stddev` of the collected text lengths,
 * `num_docs` (number of processed documents), and
 * if `use_partition` is enabled, `num_parts` (number of processed parts)

Note: This adds `plotext` to the test requirements. The processor works also without plotext, so we do not require it per default. 