### PR TITLE
add reverse relations adder document processor

### DIFF
--- a/src/pie_utils/processor/document/__init__.py
+++ b/src/pie_utils/processor/document/__init__.py
@@ -6,6 +6,12 @@ from pytorch_ie.documents import TextDocument
 
 
 @dataclass
+class DocumentWithEntitiesAndRelations(TextDocument):
+    entities: AnnotationList[LabeledSpan] = annotation_field(target="text")
+    relations: AnnotationList[BinaryRelation] = annotation_field(target="entities")
+
+
+@dataclass
 class DocumentWithPartition(TextDocument):
     partition: AnnotationList[Span] = annotation_field(target="text")
 

--- a/src/pie_utils/processor/document/reversed_relation_adder.py
+++ b/src/pie_utils/processor/document/reversed_relation_adder.py
@@ -18,13 +18,13 @@ class ReversedRelationAdder(WithStatistics):
     relations in the document. Reversing of a relation is done by swapping head and tail span in a
     relation.
 
-    :param label_suffix : A string to be appended as suffix with relation label
+    :param label_suffix : A string to be appended as suffix with relation label (the default value is _reversed)
     :param symmetric_relation_labels : List of symmetric relation labels which when reversed will use original relation
-                                        label instead of suffixed with label_suffix
+                                        label instead of suffixed with label_suffix (the default value is None)
     :param allow_already_reversed_relations : A boolean value that allows to have existing reversed relation in the
                                             document. This means that document originally contains a pair of relations
                                             which are reverse of each other. If this parameter is disabled and such
-                                            relation is found then an exception is raised.
+                                            relation is found then an exception is raised. (the default value is False)
     """
 
     def __init__(

--- a/src/pie_utils/processor/document/reversed_relation_adder.py
+++ b/src/pie_utils/processor/document/reversed_relation_adder.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import logging
+from collections import defaultdict
+
+from pytorch_ie.annotations import BinaryRelation
+
+from pie_utils.statistics import WithStatistics
+
+from ..document import DocumentWithEntitiesAndRelations
+
+logger = logging.getLogger(__name__)
+
+
+class ReversedRelationAdder(WithStatistics):
+    """TODO.
+
+    :param symmetric_relation_labels TODO
+    :param label_suffix TODO
+    :param allow_already_reversed_relations TODO
+    """
+
+    def __int__(
+        self,
+        symmetric_relation_labels: list[str] | None = None,
+        label_suffix: str = "_reversed",
+        allow_already_reversed_relations: bool = False,
+    ):
+        self.symmetric_relation_labels = symmetric_relation_labels or []
+        self.label_suffix = label_suffix
+        self.allow_already_reversed_relations = allow_already_reversed_relations
+
+    def reset_statistics(self):
+        self.added_relations = defaultdict(int)
+
+    def show_statistics(self, description: str | None = None):
+        description = description or "Statistics"
+        logger.info(
+            f"{description}: added reversed relations\n{json.dumps(dict(self.added_relations))}"
+        )
+
+    def __call__(
+        self, document: DocumentWithEntitiesAndRelations
+    ) -> DocumentWithEntitiesAndRelations:
+        # get all relations before adding any reversed
+        rels = list(document.relations)
+
+        available_relations = {(rel.head, rel.tail): rel for rel in rels}
+        for rel in rels:
+            new_label = (
+                rel.label
+                if rel.label in self.symmetric_relation_labels
+                else f"{rel.label}{self.label_suffix}"
+            )
+            new_relation = BinaryRelation(label=new_label, head=rel.tail, tail=rel.head)
+            if (new_relation.head, new_relation.tail) in available_relations:
+                # If an entity pair of reveCandidatersed relation is present in the available relations then we check if we want
+                # to allow already existing reversed relations or not. If we allow then we do not add the reversed
+                # relation to the document but move on to the next relation otherwise we generate a LookupError
+                # exception.
+                if self.allow_already_reversed_relations:
+                    continue
+                else:
+                    raise LookupError(
+                        f"Entity pair of new relation ({new_relation}) already belongs to a relation: "
+                        f"{available_relations[(new_relation.head, new_relation.tail)]}"
+                    )
+            else:
+                document.relations.append(new_relation)
+                self.added_relations[new_relation.label] += 1
+
+        return document

--- a/src/pie_utils/processor/document/reversed_relation_adder.py
+++ b/src/pie_utils/processor/document/reversed_relation_adder.py
@@ -14,11 +14,17 @@ logger = logging.getLogger(__name__)
 
 
 class ReversedRelationAdder(WithStatistics):
-    """TODO.
+    """ReversedRelationAdder adds binary relations to a document by reversing already existing
+    relations in the document. Reversing of a relation is done by swapping head and tail span in a
+    relation.
 
-    :param symmetric_relation_labels TODO
-    :param label_suffix TODO
-    :param allow_already_reversed_relations TODO
+    :param label_suffix : A string to be appended as suffix with relation label
+    :param symmetric_relation_labels : List of symmetric relation labels which when reversed will use original relation
+                                        label instead of suffixed with label_suffix
+    :param allow_already_reversed_relations : A boolean value that allows to have existing reversed relation in the
+                                            document. This means that document originally contains a pair of relations
+                                            which are reverse of each other. If this parameter is disabled and such
+                                            relation is found then an exception is raised.
     """
 
     def __init__(

--- a/tests/processor/document/test_reversed_relation_adder.py
+++ b/tests/processor/document/test_reversed_relation_adder.py
@@ -1,0 +1,148 @@
+import copy
+
+import pytest
+from pytorch_ie.annotations import BinaryRelation, LabeledSpan
+
+from pie_utils.processor.document import DocumentWithEntitiesAndRelations
+from pie_utils.processor.document.reversed_relation_adder import ReversedRelationAdder
+
+TEXT1 = "Lily is mother of Harry."
+TEXT2 = "Beth greets Emma."
+TEXT3 = "Jamie meets John."
+
+ENTITY_LILY_TEXT1 = LabeledSpan(start=0, end=4, label="person")
+ENTITY_HARRY_TEXT1 = LabeledSpan(start=18, end=23, label="person")
+
+REL_LILY_MOTHER_OF_HARRY = BinaryRelation(
+    head=ENTITY_LILY_TEXT1, tail=ENTITY_HARRY_TEXT1, label="mother_of"
+)
+REL_HARRY_SON_OF_LILY = BinaryRelation(
+    head=ENTITY_HARRY_TEXT1, tail=ENTITY_LILY_TEXT1, label="son_of"
+)
+
+ENTITY_BETH_TEXT2 = LabeledSpan(start=0, end=4, label="person")
+ENTITY_EMMA_TEXT2 = LabeledSpan(start=12, end=16, label="person")
+
+ENTITY_JAMIE_TEXT3 = LabeledSpan(start=0, end=5, label="person")
+ENTITY_JOHN_TEXT3 = LabeledSpan(start=12, end=16, label="person")
+
+REL_JAMIE_MEETS_JOHN = BinaryRelation(
+    head=ENTITY_JAMIE_TEXT3, tail=ENTITY_JOHN_TEXT3, label="meets"
+)
+REL_JOHN_MEETS_R_JAMIE = BinaryRelation(
+    head=ENTITY_JOHN_TEXT3, tail=ENTITY_JAMIE_TEXT3, label="meets_reversed"
+)
+REL_JOHN_MEETS_S_JAMIE = BinaryRelation(
+    head=ENTITY_JOHN_TEXT3, tail=ENTITY_JAMIE_TEXT3, label="meets"
+)
+
+
+def test_reversed_relation():
+
+    reverse_relation_adder = ReversedRelationAdder(
+        symmetric_relation_labels=[],
+    )
+
+    document = DocumentWithEntitiesAndRelations(text=TEXT3)
+    document.entities.extend([ENTITY_JAMIE_TEXT3, ENTITY_JOHN_TEXT3])
+    document.relations.append(REL_JAMIE_MEETS_JOHN)
+
+    original_document = copy.deepcopy(document)
+    reverse_relation_adder(document)
+
+    # Document contains two entities and one relation. One reverse relation will be created resulting in total two
+    # relations.
+    relations = document.relations
+    assert len(relations) == 2
+    original_relations = original_document.relations
+    assert len(original_relations) == 1
+    assert str(relations[0]) == str(original_relations[0])
+    relation = relations[1]
+    assert str(relation.head) == str(ENTITY_JOHN_TEXT3)
+    assert str(relation.tail) == str(ENTITY_JAMIE_TEXT3)
+    assert relation.label == "meets_reversed"
+    statistics = {
+        "added_relations": {"meets_reversed": 1},
+        "already_reversed_relations": {},
+        "num_available_relations": 1,
+        "num_added_relations": 1,
+    }
+    assert reverse_relation_adder._statistics == statistics
+    reverse_relation_adder.show_statistics()
+
+
+def test_with_already_reversed_relations():
+    # since allow_already_reversed_relations is False by default and document contains reversed relations, it will
+    # generate LookupError exception.
+    reverse_relation_adder = ReversedRelationAdder(
+        symmetric_relation_labels=[],
+    )
+    document = DocumentWithEntitiesAndRelations(text=TEXT1)
+    document.entities.extend([ENTITY_LILY_TEXT1, ENTITY_HARRY_TEXT1])
+    document.relations.extend([REL_LILY_MOTHER_OF_HARRY, REL_HARRY_SON_OF_LILY])
+
+    with pytest.raises(LookupError) as e:
+        reverse_relation_adder(document)
+    assert (
+        str(e.value) == f"Entity pair of new relation "
+        f"({BinaryRelation(label='mother_of_reversed', head=ENTITY_HARRY_TEXT1, tail=ENTITY_LILY_TEXT1)}) "
+        f"already belongs to a relation: {REL_HARRY_SON_OF_LILY}"
+    )
+
+
+def test_with_already_reversed_relations_allow():
+    reverse_relation_adder_with_allow_already_reversed_relations = ReversedRelationAdder(
+        symmetric_relation_labels=[],
+        allow_already_reversed_relations=True,
+    )
+
+    document = DocumentWithEntitiesAndRelations(text=TEXT1)
+    document.entities.extend([ENTITY_LILY_TEXT1, ENTITY_HARRY_TEXT1])
+    document.relations.extend([REL_LILY_MOTHER_OF_HARRY, REL_HARRY_SON_OF_LILY])
+
+    original_document = copy.deepcopy(document)
+    reverse_relation_adder_with_allow_already_reversed_relations(document)
+
+    # Document contains two entities and two relations which are reverse of each other. After setting
+    # allow_already_reversed_relations as True, we do not expect any new relation to be created.
+
+    relations = document.relations
+    assert len(relations) == 2
+    original_relations = original_document.relations
+    assert len(original_relations) == 2
+    assert str(relations[0]) == str(original_relations[0])
+    assert str(relations[1]) == str(original_relations[1])
+
+    statistics = {
+        "added_relations": {},
+        "already_reversed_relations": {"mother_of_reversed": 1, "son_of_reversed": 1},
+        "num_available_relations": 2,
+        "num_added_relations": 0,
+    }
+    assert reverse_relation_adder_with_allow_already_reversed_relations._statistics == statistics
+
+
+def test_symmetric_relation():
+    reverse_relation_adder_with_sym_rel = ReversedRelationAdder(
+        symmetric_relation_labels=["meets"],
+    )
+
+    document = DocumentWithEntitiesAndRelations(text=TEXT3)
+    document.entities.extend([ENTITY_JAMIE_TEXT3, ENTITY_JOHN_TEXT3])
+    document.relations.append(REL_JAMIE_MEETS_JOHN)
+
+    original_document = copy.deepcopy(document)
+    reverse_relation_adder_with_sym_rel(document)
+
+    # Document contains a relation labeled 'meets' which is also given in a list as symmetric_relation_labels.
+    # Therefore, a reverse relation will be created without suffix '_reversed'. Finally, there will be two relations
+    # both containing relation label as 'meets'
+    relations = document.relations
+    assert len(relations) == 2
+    original_relations = original_document.relations
+    assert len(original_relations) == 1
+    assert str(relations[0]) == str(original_relations[0])
+    relation = relations[1]
+    assert str(relation.head) == str(ENTITY_JOHN_TEXT3)
+    assert str(relation.tail) == str(ENTITY_JAMIE_TEXT3)
+    assert relation.label == "meets"


### PR DESCRIPTION
This PR implements the document processor `ReversedRelationAdder`. `ReversedRelationAdder` adds binary relations to the document by reversing already available relations in the document.

Label for reversed relation is suffixed via a parameter `label_suffix`. However, if there is any symmetric relation in the document then we can prevent suffixing its label by using `symmetric_relation_labels` parameter. `allow_already_reversed_relations` allows to keep existing reversed relations in the document.